### PR TITLE
Improve two-point perspective camera workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ More detailed instructions can be found in the [Blender Manual](https://docs.ble
 ## Usage
 
 1. Ensure your scene has at least one camera.
-2. In the Properties panel, navigate to the `Scene` tab.
-3. Find the `Two Point Perspective` section.
+2. In the 3D Viewport, open the Sidebar with `N`.
+3. Go to the `Camera` tab and find the `Two-Point Perspective` panel.
 4. Optionally, set a custom target angle by checking the "Custom target angle" box and adjusting the angle value.
 5. Click the "Create Two Point Perspective Camera" button.
 

--- a/__init__.py
+++ b/__init__.py
@@ -27,9 +27,10 @@ def register():
 
 
 def unregister():
-    for c in classes:
+    if hasattr(bpy.types.Scene, "two_point_perspective"):
+        del bpy.types.Scene.two_point_perspective
+    for c in reversed(classes):
         bpy.utils.unregister_class(c)
-    del bpy.types.Scene.two_point_perspective
 
 
 if __name__ == "__main__":

--- a/core.py
+++ b/core.py
@@ -58,9 +58,7 @@ def add_two_point_perspective_camera(cam_obj, auto_direction=False, custom_direc
     opposite_side = -math.tan(angle) * adjacent_side
     offset = (adjacent_side / math.cos(angle)) - adjacent_side
     offset_vec = 0, 0, offset
-    inv = cam_obj.matrix_world.copy()
-    inv.invert()
-    rotated_offset_vec = Vector(offset_vec) @ inv
+    rotated_offset_vec = cam_obj.matrix_world.to_quaternion() @ Vector(offset_vec)
     corrected_position = cam_position + rotated_offset_vec
 
 

--- a/two_point_perspective_ot.py
+++ b/two_point_perspective_ot.py
@@ -41,7 +41,7 @@ class Two_Point_Perspective_OT_Operator(Operator):
                     break
             else:
                 self.report({"ERROR"}, "There is no camera in the scene")
-                return
+                return {"CANCELLED"}
 
         active_cam = add_two_point_perspective_camera(
             context.scene.camera,

--- a/two_point_perspective_pt.py
+++ b/two_point_perspective_pt.py
@@ -3,25 +3,25 @@ from bpy.types import Panel
 
 
 class Camera_PT_Panel(Panel):
-    bl_space_type = "PROPERTIES"
-    bl_region_type = "WINDOW"
-    bl_context = "scene"
-    bl_label = "Two-Point Perspective Camera"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
     bl_category = "Camera"
+    bl_label = "Two-Point Perspective"
+    bl_idname = "VIEW3D_PT_two_point_perspective"
 
     def draw(self, context):
         layout = self.layout
         two_point_perspective = context.scene.two_point_perspective
-        
+
         box = layout.box()
 
         row0 = box.row(align=True)
         col0_0 = row0.column()
         col0_0.prop(two_point_perspective, "custom_angle", text="Custom Angle")
-        
+
         col0_1 = row0.column()
         col0_1.enabled = two_point_perspective.custom_angle
-        col0_1.prop(context.scene.two_point_perspective,"custom_angle_value")
-        
+        col0_1.prop(two_point_perspective, "custom_angle_value", text="Angle")
+
         layout.separator()
         layout.operator("scene.two_point_perspective", icon="CON_CAMERASOLVER")


### PR DESCRIPTION
Summary
This PR improves usability and reliability for the Two Point Perspective add-on.

What changed
Moved the panel to the 3D Viewport sidebar under the Camera tab
Fixed camera offset rotation by using the camera's world quaternion
Returned {"CANCELLED"} when no scene camera is available
Made unregister cleanup safer for the scene property
Updated the README to match the new UI location